### PR TITLE
bugfix: error is displayed if the login is unsuccessful

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -25,6 +25,7 @@ export async function login(
   } catch (error) {
     const typedError = error as Error;
     console.error("Error logging in:", typedError.message);
+    alert("Error logging in: " + typedError.message);
   }
 }
 


### PR DESCRIPTION
This fixed the error described in Testcase #06-04 - the user was not informed why the login didn't work